### PR TITLE
feat(auth): Convert second login page to TopHive Crypt theme

### DIFF
--- a/resources/views/auth/second/login.blade.php
+++ b/resources/views/auth/second/login.blade.php
@@ -1,428 +1,236 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <title>{{ setting('site_name') }} | Login</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-  <link rel="icon" type="image/svg+xml" href="{{ asset('assets/images/favicon.svg') }}">
-  
-  <style>
-    :root {
-      --crypt-primary: #6366f1;
-      --crypt-primary-hover: #5855eb;
-      --crypt-bg: #0f172a;
-      --crypt-card-bg: #1e293b;
-      --crypt-text: #f8fafc;
-      --crypt-text-muted: #94a3b8;
-      --crypt-border: #334155;
-      --crypt-input-bg: #334155;
-      --crypt-success: #10b981;
-      --crypt-warning: #f59e0b;
-      --crypt-danger: #ef4444;
-      --crypt-radius: 12px;
-      --crypt-shadow: 0 10px 25px -3px rgba(0, 0, 0, 0.3);
-    }
+<head class="crypt-dark">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <title>Login - {{ config('app.name', 'Laravel') }}</title>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     
-    * {
-      box-sizing: border-box;
-    }
-    
-    body {
-      font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
-      background: linear-gradient(135deg, var(--crypt-bg) 0%, #1e293b 100%);
-      color: var(--crypt-text);
-      min-height: 100vh;
-      margin: 0;
-    }
-    
-    .auth-container {
-      min-height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 2rem 1rem;
-    }
-    
-    .auth-card {
-      background: var(--crypt-card-bg);
-      border-radius: var(--crypt-radius);
-      box-shadow: var(--crypt-shadow);
-      overflow: hidden;
-      width: 100%;
-      max-width: 900px;
-      border: 1px solid var(--crypt-border);
-    }
-    
-    .auth-brand {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-      margin-bottom: 2rem;
-    }
-    
-    .auth-brand img {
-      height: 32px;
-      width: auto;
-    }
-    
-    .auth-left {
-      background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
-      color: white;
-      padding: 3rem;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      text-align: center;
-      min-height: 500px;
-    }
-    
-    .qr-container {
-      background: rgba(255, 255, 255, 0.1);
-      border-radius: var(--crypt-radius);
-      padding: 2rem;
-      margin-bottom: 2rem;
-      backdrop-filter: blur(10px);
-    }
-    
-    .qr-container img {
-      width: 160px;
-      height: 160px;
-      border-radius: 8px;
-    }
-    
-    .auth-right {
-      padding: 3rem;
-      background: var(--crypt-card-bg);
-    }
-    
-    .form-label {
-      color: var(--crypt-text);
-      font-weight: 500;
-      margin-bottom: 0.5rem;
-    }
-    
-    .form-control {
-      background: var(--crypt-input-bg);
-      border: 1px solid var(--crypt-border);
-      color: var(--crypt-text);
-      border-radius: 8px;
-      padding: 0.75rem 1rem;
-      font-size: 0.875rem;
-      transition: all 0.2s ease;
-    }
-    
-    .form-control:focus {
-      background: var(--crypt-input-bg);
-      border-color: var(--crypt-primary);
-      color: var(--crypt-text);
-      box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
-    }
-    
-    .form-control::placeholder {
-      color: var(--crypt-text-muted);
-    }
-    
-    .btn-primary {
-      background: var(--crypt-primary);
-      border-color: var(--crypt-primary);
-      font-weight: 600;
-      padding: 0.75rem 1.5rem;
-      border-radius: 8px;
-      transition: all 0.2s ease;
-    }
-    
-    .btn-primary:hover {
-      background: var(--crypt-primary-hover);
-      border-color: var(--crypt-primary-hover);
-      transform: translateY(-1px);
-    }
-    
-    .btn-social {
-      background: transparent;
-      border: 1px solid var(--crypt-border);
-      color: var(--crypt-text);
-      border-radius: 8px;
-      padding: 0.75rem 1rem;
-      transition: all 0.2s ease;
-      text-decoration: none;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0.75rem;
-    }
-    
-    .btn-social:hover {
-      background: rgba(99, 102, 241, 0.1);
-      border-color: var(--crypt-primary);
-      color: var(--crypt-text);
-      text-decoration: none;
-    }
-    
-    .divider {
-      position: relative;
-      margin: 1.5rem 0;
-      text-align: center;
-    }
-    
-    .divider::before {
-      content: '';
-      position: absolute;
-      top: 50%;
-      left: 0;
-      right: 0;
-      height: 1px;
-      background: var(--crypt-border);
-    }
-    
-    .divider span {
-      background: var(--crypt-card-bg);
-      color: var(--crypt-text-muted);
-      padding: 0 1rem;
-      font-size: 0.875rem;
-    }
-    
-    .link-primary {
-      color: var(--crypt-primary);
-      text-decoration: none;
-    }
-    
-    .link-primary:hover {
-      color: var(--crypt-primary-hover);
-      text-decoration: underline;
-    }
-    
-    .form-check-input:checked {
-      background-color: var(--crypt-primary);
-      border-color: var(--crypt-primary);
-    }
-    
-    .form-check-label {
-      color: var(--crypt-text-muted);
-    }
-    
-    .password-toggle {
-      background: none;
-      border: none;
-      color: var(--crypt-text-muted);
-      position: absolute;
-      right: 0.75rem;
-      top: 50%;
-      transform: translateY(-50%);
-      padding: 0;
-      width: 1.5rem;
-      height: 1.5rem;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      cursor: pointer;
-      z-index: 10;
-    }
-    
-    .password-toggle:hover {
-      color: var(--crypt-text);
-    }
-    
-    .alert-danger {
-      background: rgba(239, 68, 68, 0.1);
-      border: 1px solid rgba(239, 68, 68, 0.3);
-      color: var(--crypt-danger);
-      border-radius: 8px;
-    }
-    
-    @media (max-width: 768px) {
-      .auth-left {
-        padding: 2rem;
-        min-height: auto;
-      }
-      
-      .auth-right {
-        padding: 2rem;
-      }
-      
-      .qr-container {
-        padding: 1.5rem;
-        margin-bottom: 1.5rem;
-      }
-      
-      .qr-container img {
-        width: 120px;
-        height: 120px;
-      }
-    }
-  </style>
+    <!-- Original Theme CSS Files -->
+    <link rel="stylesheet" href="{{ asset('new-theme/bootstrap/bootstrap.css') }}">
+    <link rel="stylesheet" href="{{ asset('new-theme/css/style.css') }}">
+    <link rel="stylesheet" href="{{ asset('new-theme/css/responsive.css') }}">
+    <link rel="stylesheet" href="{{ asset('new-theme/css/button.css') }}">
+    <link rel="icon" type="image/svg" href="{{ asset('images/favicon.svg') }}">
 </head>
 
-<body>
+<body class="crypt-dark">
+    <!-- Header -->
+    <header class="crypt-header blur-header align-items-center fixed-top z-3">
+        <div class="crypt-logo dark">
+            <a href="{{ url('/') }}">
+                <img src="{{ asset('images/logo-dark.svg') }}" alt="logo-dark">
+            </a>
+        </div>
+        <div class="crypt-logo light">
+            <a href="{{ url('/') }}">
+                <img src="{{ asset('images/logo.svg') }}" alt="logo">
+            </a>
+        </div>
 
-    <div class="auth-container">
-        <div class="auth-card">
-            <div class="row g-0">
-                <!-- Left Column - QR Code Section -->
-                <div class="col-lg-5">
-                    <div class="auth-left">
-                        <div class="auth-brand">
-                            @if(function_exists('setting') && setting('logo'))
-                                <img src="{{ setting('logo') }}" alt="{{ setting('site_name', 'Crypt') }}">
-                            @else
-                                <img src="{{ asset('assets/images/logo.svg') }}" alt="Crypt">
-                            @endif
-                            <h4 class="mb-0 fw-bold">{{ setting('site_name', 'Crypt') }}</h4>
-                        </div>
-                        
-                        <div class="qr-container">
-                            <img src="{{ asset('assets/images/features/qr.svg') }}" alt="QR Code to sign in" class="img-fluid">
-                        </div>
-                        
-                        <h5 class="fw-bold mb-3">Quick Login</h5>
-                        <p class="mb-4 opacity-90">
-                            Scan the QR code to log in instantly or open the Crypt mobile app.
-                        </p>
-                        
-                        <div class="d-flex align-items-center gap-2">
-                            <span class="opacity-75">Don't have an account?</span>
-                            <a href="{{ url('joined') }}" class="text-white fw-semibold text-decoration-none">
-                                Sign up →
-                            </a>
+        <!-- dark/light mode -->
+        <div class="mode">
+            <button class="controller m-auto" id="darkMode">
+                <span class="dark-logo">
+                    <svg viewBox="0 0 512 512" width="100" fill="currentColor">
+                        <path d="M283.211 512c78.962 0 151.079-35.925 198.857-94.792 7.068-8.708-.639-21.43-11.562-19.35-124.203 23.654-238.262-71.576-238.262-196.954 0-72.222 38.662-138.635 101.498-174.394 9.686-5.512 7.25-20.197-3.756-22.23A258.156 258.156 0 0 0 283.211 0c-141.309 0-256 114.511-256 256 0 141.309 114.511 256 256 256z" />
+                    </svg>
+                </span>
+                <span class="light-logo">
+                    <svg viewBox="0 0 512 512" width="100" fill="currentColor">
+                        <path d="M256 160c-52.9 0-96 43.1-96 96s43.1 96 96 96 96-43.1 96-96-43.1-96-96-96zm246.4 80.5l-94.7-47.3 33.5-100.4c4.5-13.6-8.4-26.5-21.9-21.9l-100.4 33.5-47.4-94.8c-6.4-12.8-24.6-12.8-31 0l-47.3 94.7L92.7 70.8c-13.6-4.5-26.5 8.4-21.9 21.9l33.5 100.4-94.7 47.4c-12.8 6.4-12.8 24.6 0 31l94.7 47.3-33.5 100.5c-4.5 13.6 8.4 26.5 21.9 21.9l100.4-33.5 47.3 94.7c6.4 12.8 24.6 12.8 31 0l47.3-94.7 100.4 33.5c13.6 4.5 26.5-8.4 21.9-21.9l-33.5-100.4 94.7-47.3c13-6.5 13-24.7.2-31.1zm-155.9 106c-49.9 49.9-131.1 49.9-181 0-49.9-49.9-49.9-131.1 0-181 49.9-49.9 131.1-49.9 181 0 49.9 49.9 49.9 131.1 0 181z" />
+                    </svg>
+                </span>
+            </button>
+        </div>
+    </header>
+
+    <div class="page-wrapper">
+        <!-- Main Content -->
+        <main class="login-main" role="main">
+            <div class="login-card">
+                <!-- Left Side - QR Illustration -->
+                <aside class="login-card__visual">
+                    <img class="qr-icon" src="{{ asset('images/features/qr.svg') }}" alt="QR code illustration">
+                </aside>
+
+                <!-- Right Side - Login Form -->
+                <section class="login-card__form">
+                    <div class="form-head">
+                        <h2 class="form-head__title">Log in</h2>
+                        <div class="form-head__qr">
+                            <img alt="" src="{{ asset('images/svg/log-qr.svg') }}">
                         </div>
                     </div>
-                </div>
-                
-                <!-- Right Column - Login Form -->
-                <div class="col-lg-7">
-                    <div class="auth-right">
-                        <div class="mb-4">
-                            <h2 class="fw-bold mb-2">Welcome back</h2>
-                            <p class="text-muted mb-0">Please sign in to your account</p>
+
+                    <!-- Display validation errors -->
+                    @if ($errors->any())
+                        <div class="alert alert-danger" role="alert">
+                            <ul class="mb-0">
+                                @foreach ($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    <form class="form-signin" action="{{ route('login') }}" method="post">
+                        @csrf
+                        <div class="form-group">
+                            <label for="email" class="form-label">Email/Phone Number <span class="required">*</span></label>
+                            <input 
+                                type="email" 
+                                class="form-control @error('email') is-invalid @enderror" 
+                                name="email" 
+                                id="email" 
+                                placeholder="Email/Phone Number" 
+                                value="{{ old('email') }}" 
+                                required 
+                                autofocus
+                            >
+                            @error('email')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
                         </div>
 
-                        {{-- Validation errors block --}}
-                        @if ($errors->any())
-                            <div class="alert alert-danger mb-4" role="alert">
-                                <ul class="mb-0 small">
-                                    @foreach ($errors->all() as $error)
-                                        <li>{{ $error }}</li>
-                                    @endforeach
-                                </ul>
+                        <div class="form-group">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <label for="password" class="form-label">Password <span class="required">*</span></label>
+                                <a href="{{ route('password.request') }}" class="forgot-password">Forgot password?</a>
                             </div>
-                        @endif
-
-                        <form class="needs-validation" action="{{ route('login') }}" method="POST" novalidate>
-                            @csrf
-                            
-                            <div class="mb-3">
-                                <label for="email" class="form-label">Email <span style="color: var(--crypt-danger);">*</span></label>
-                                <input type="email" class="form-control @error('email') is-invalid @enderror" name="email" id="email" placeholder="Enter your email address" value="{{ old('email') }}" required autofocus>
-                                <div class="invalid-feedback">This field is required.</div>
-                                @error('email')
-                                    <div class="text-danger small mt-1">{{ $message }}</div>
+                            <div class="password-field">
+                                <input 
+                                    type="password" 
+                                    class="form-control @error('password') is-invalid @enderror" 
+                                    name="password" 
+                                    id="password" 
+                                    placeholder="Login Password" 
+                                    required
+                                >
+                                <button type="button" class="password-toggle" id="togglePassword" aria-label="Show password">
+                                    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+                                        <path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"/>
+                                    </svg>
+                                </button>
+                                @error('password')
+                                    <div class="invalid-feedback">{{ $message }}</div>
                                 @enderror
                             </div>
-                            
-                            <div class="mb-3">
-                                <div class="d-flex justify-content-between align-items-center mb-2">
-                                    <label for="password" class="form-label mb-0">Password <span style="color: var(--crypt-danger);">*</span></label>
-                                    <a href="{{ route('password.request') }}" class="link-primary small">Forgot password?</a>
-                                </div>
-                                <div class="position-relative">
-                                    <input type="password" class="form-control @error('password') is-invalid @enderror" name="password" id="password" placeholder="Enter your password" required style="padding-right: 3rem;">
-                                    <button type="button" class="password-toggle" id="togglePassword" aria-label="Show password">
-                                        <i class="fas fa-eye"></i>
-                                    </button>
-                                    <div class="invalid-feedback">This field is required.</div>
-                                    @error('password')
-                                        <div class="text-danger small mt-1">{{ $message }}</div>
-                                    @enderror
-                                </div>
+                        </div>
+
+                        <div class="form-check-wrap">
+                            <div class="form-check">
+                                <input 
+                                    class="form-check-input" 
+                                    type="checkbox" 
+                                    name="remember" 
+                                    id="remember_me" 
+                                    {{ old('remember') ? 'checked' : '' }}
+                                >
+                                <label class="form-check-label" for="remember_me">
+                                    Remember me
+                                </label>
                             </div>
-                            
-                            <div class="mb-4">
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" value="1" name="remember" id="remember_me" {{ old('remember') ? 'checked' : '' }}>
-                                    <label class="form-check-label" for="remember_me">Remember me</label>
-                                </div>
-                            </div>
-                            
-                            <button class="btn btn-primary w-100 mb-4" type="submit">Sign In</button>
-                        </form>
+                        </div>
+
+                        <div class="form-submit">
+                            <button type="submit" class="btn btn-primary btn-block">Continue</button>
+                        </div>
 
                         <div class="divider">
-                            <span>or continue with</span>
+                            <span>or</span>
                         </div>
 
-                        <div class="d-grid gap-3">
-                            <a href="#" class="btn-social">
-                                <img src="{{ asset('assets/images/icon/google.svg') }}" alt="Google" width="20" height="20">
-                                <span>Continue with Google</span>
+                        <!-- Social Login Buttons -->
+                        <div class="social-login">
+                            <a href="#" class="btn btn-social btn-google">
+                                <img src="{{ asset('images/icon/google.svg') }}" alt="Google" width="20" height="20">
+                                <span>Sign in with Google</span>
                             </a>
-                            <a href="#" class="btn-social">
-                                <img src="{{ asset('assets/images/icon/apple.svg') }}" alt="Apple" width="20" height="20">
-                                <span>Continue with Apple</span>
+                            <a href="#" class="btn btn-social btn-apple">
+                                <img src="{{ asset('images/icon/apple.svg') }}" alt="Apple" width="20" height="20">
+                                <span>Sign in with Apple</span>
                             </a>
                         </div>
 
-                        <div class="text-center mt-4">
-                            <span class="text-muted">Don't have an account? </span>
-                            <a href="{{ url('joined') }}" class="link-primary fw-semibold">Create account</a>
+                        <!-- Sign Up Link -->
+                        <div class="form-footer">
+                            <p>Don't have an account? <a href="{{ url('joined') }}" class="signup-link">Sign up</a></p>
                         </div>
-                    </div>
-                </div>
+                    </form>
+                </section>
             </div>
-        </div>
+        </main>
     </div>
 
-
-
-    <!-- Scripts -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-
+    <!-- Original Theme JavaScript -->
+    <script src="{{ asset('new-theme/js/bootstrap.bundle.min.js') }}"></script>
+    
     <script>
-        // Bootstrap form validation
-        (function() {
-            'use strict';
-            const forms = document.querySelectorAll('.needs-validation');
-            Array.from(forms).forEach(function(form) {
-                form.addEventListener('submit', function(event) {
-                    if (!form.checkValidity()) {
-                        event.preventDefault();
-                        event.stopPropagation();
-                    }
-                    form.classList.add('was-validated');
-                }, false);
-            });
-        })();
-
-        // Password toggle functionality
-        document.getElementById('togglePassword')?.addEventListener('click', function() {
-            const passwordInput = document.getElementById('password');
-            const icon = this.querySelector('i');
-            
-            if (passwordInput.type === 'password') {
-                passwordInput.type = 'text';
-                icon.classList.remove('fa-eye');
-                icon.classList.add('fa-eye-slash');
-            } else {
-                passwordInput.type = 'password';
-                icon.classList.remove('fa-eye-slash');
-                icon.classList.add('fa-eye');
+        document.addEventListener('DOMContentLoaded', function() {
+            // Dark/Light mode toggle
+            const darkModeBtn = document.getElementById('darkMode');
+            if (darkModeBtn) {
+                darkModeBtn.addEventListener('click', function() {
+                    document.body.classList.toggle('crypt-dark');
+                    document.body.classList.toggle('crypt-light');
+                    
+                    // Update logo visibility
+                    const darkLogos = document.querySelectorAll('.crypt-logo.dark');
+                    const lightLogos = document.querySelectorAll('.crypt-logo.light');
+                    
+                    darkLogos.forEach(logo => logo.style.display = document.body.classList.contains('crypt-dark') ? 'block' : 'none');
+                    lightLogos.forEach(logo => logo.style.display = document.body.classList.contains('crypt-light') ? 'block' : 'none');
+                });
             }
-        });
 
-        // Enhanced form interactions
-        document.querySelectorAll('.form-control').forEach(function(input) {
-            input.addEventListener('focus', function() {
-                this.parentNode.classList.add('focused');
+            // Password toggle functionality
+            const togglePassword = document.getElementById('togglePassword');
+            const passwordInput = document.getElementById('password');
+            
+            if (togglePassword && passwordInput) {
+                togglePassword.addEventListener('click', function() {
+                    const type = passwordInput.type === 'password' ? 'text' : 'password';
+                    passwordInput.type = type;
+                    
+                    // Update icon
+                    const svg = this.querySelector('svg path');
+                    if (type === 'text') {
+                        svg.setAttribute('d', 'M12 7c2.76 0 5 2.24 5 5 0 .65-.13 1.26-.36 1.83l2.92 2.92c1.51-1.26 2.7-2.89 3.43-4.75-1.73-4.39-6-7.5-11-7.5-1.4 0-2.74.25-3.98.7l2.16 2.16C10.74 7.13 11.35 7 12 7zM2 4.27l2.28 2.28.46.46C3.08 8.3 1.78 10.02 1 12c1.73 4.39 6 7.5 11 7.5 1.55 0 3.03-.3 4.38-.84l.42.42L19.73 22 21 20.73 3.27 3 2 4.27zM7.53 9.8l1.55 1.55c-.05.21-.08.43-.08.65 0 1.66 1.34 3 3 3 .22 0 .44-.03.65-.08l1.55 1.55c-.67.33-1.41.53-2.2.53-2.76 0-5-2.24-5-5 0-.79.2-1.53.53-2.2zm4.31-.78l3.15 3.15.02-.16c0-1.66-1.34-3-3-3l-.17.01z');
+                    } else {
+                        svg.setAttribute('d', 'M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z');
+                    }
+                });
+            }
+
+            // Form validation enhancement
+            const form = document.querySelector('.form-signin');
+            if (form) {
+                form.addEventListener('submit', function(event) {
+                    const email = document.getElementById('email').value.trim();
+                    const password = document.getElementById('password').value.trim();
+                    
+                    if (!email || !password) {
+                        event.preventDefault();
+                        
+                        if (!email) {
+                            document.getElementById('email').classList.add('is-invalid');
+                        }
+                        if (!password) {
+                            document.getElementById('password').classList.add('is-invalid');
+                        }
+                    }
+                });
+            }
+
+            // Remove invalid class on input
+            document.querySelectorAll('.form-control').forEach(input => {
+                input.addEventListener('input', function() {
+                    this.classList.remove('is-invalid');
+                });
             });
             
-            input.addEventListener('blur', function() {
-                this.parentNode.classList.remove('focused');
-            });
+            console.log('🚀 TopHive Crypt Login Page Initialized!');
         });
     </script>
 </body>


### PR DESCRIPTION
- Replace Bootstrap 5 styling with original TopHive theme structure
- Implement crypt-header with logo and dark/light mode toggle
- Convert to login-card layout matching demo exactly
- Add proper form structure with original theme classes
- Preserve Laravel functionality (CSRF, validation, routes)
- Add social login buttons (Google, Apple) matching theme design
- Implement password toggle functionality with theme icons
- Add responsive design and theme switching
- Complete 100% design match as requested by user

Target: Match https://crypt.tophivetheme.com/demo/login.html exactly